### PR TITLE
Add CLI name options for patient creation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,11 @@ To add support for new FHIR backends:
 All examples automatically load configuration from your `.env` file. To run any example:  
 
 ```bash
-# Simple patient creation
-lua examples/create_patient.lua
+# Simple patient creation (optional first and last name)
+lua examples/create_patient.lua [FirstName] [LastName]
 
-# Async patient creation  
-lua examples/create_patient_async.lua
+# Async patient creation (optional first and last name)
+lua examples/create_patient_async.lua [FirstName] [LastName]
 
 # Find patient by ID or name
 lua examples/find_patient.lua f16195fd-25d0-4294-ad6f-8c1046897293

--- a/examples/create_patient.lua
+++ b/examples/create_patient.lua
@@ -2,6 +2,10 @@
 
 local fhir = require("fhir")
 
+-- Get optional first and last name from CLI arguments
+local given_name = arg[1] or "Scottie"
+local family_name = arg[2] or "Pippen"
+
 -- Create client (automatically loads .env configuration)
 local client = fhir.client.new({
   backend = "google_healthcare"
@@ -13,8 +17,8 @@ local patient = fhir.resource:new("Patient", {
   name = {
     {
       use = "official",
-      family = "Pippen",
-      given = {"Scottie"}
+      family = family_name,
+      given = {given_name}
     }
   },
   gender = "male",

--- a/examples/create_patient_async.lua
+++ b/examples/create_patient_async.lua
@@ -3,6 +3,10 @@
 local AsyncClient = require("fhir.async_client")
 local Resource = require("fhir.resource")
 
+-- Get optional first and last name from CLI arguments
+local given_name = arg[1] or "Shaka"
+local family_name = arg[2] or "Zulu"
+
 -- Create async client (automatically loads .env configuration)
 local client = AsyncClient.new({
   backend = "google_healthcare"
@@ -14,8 +18,8 @@ local patient = Resource:new("Patient", {
   name = {
     {
       use = "official",
-      family = "Zulu",
-      given = {"Shaka"}
+      family = family_name,
+      given = {given_name}
     }
   },
   gender = "female",


### PR DESCRIPTION
## Summary
- allow providing first and last name via CLI in patient creation examples
- update README instructions for new optional arguments

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840600034f0832687d58e3714d5a074